### PR TITLE
Add social and phone auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,7 @@ pnpm run build
 ```
 
 You can run the Supabase SQL scripts using the Supabase dashboard or with a command-line tool such as `psql`.
+
+## Authentification sociale et téléphonique
+
+L'application prend désormais en charge la connexion via Google ou GitHub ainsi que la connexion par téléphone avec envoi d'OTP grâce à Supabase Auth.


### PR DESCRIPTION
## Summary
- add social login and phone OTP logic in `AuthContext`
- enhance login form with Google/GitHub buttons and phone OTP form
- document new authentication options in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6856c3d44b5083318dec2b061fc9eadc