### PR TITLE
Fix profile creation error handling

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -206,11 +206,7 @@ export const AuthProvider = ({ children }) => {
               .from('profiles')
               .insert([minimalProfile])
               .select()
-              .single()
-              .catch(err => {
-                console.error('Insert profile error caught:', err);
-                return { data: null, error: err };
-              });
+              .single();
               
             if (insertError) {
               console.warn('Failed to create minimal profile:', insertError);


### PR DESCRIPTION
## Summary
- adjust profile creation call to remove internal catch handler
- retain toast messages for profile update

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6857508957a483319aa36ec546715101