### PR TITLE
Add profile trigger SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ connection:
 ```bash
 psql < supabase_schema_setup.sql
 psql < supabase_add_description_column.sql
+psql < supabase_create_profile_trigger.sql
+psql < supabase_create_avatars_bucket.sql
 ```
 
 Running these scripts creates the required tables (including `events`) and

--- a/supabase_create_avatars_bucket.sql
+++ b/supabase_create_avatars_bucket.sql
@@ -1,0 +1,7 @@
+-- Create "avatars" bucket if it doesn't exist
+-- Adjust the privacy (public) as needed
+INSERT INTO storage.buckets (id, name, public)
+SELECT 'avatars', 'avatars', true
+WHERE NOT EXISTS (
+    SELECT 1 FROM storage.buckets WHERE id = 'avatars'
+);

--- a/supabase_create_profile_trigger.sql
+++ b/supabase_create_profile_trigger.sql
@@ -1,0 +1,20 @@
+-- Function and trigger to auto-create profile after user registration
+-- Creates a profile row for each new auth user
+
+-- Function definition (security definer to bypass RLS)
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.profiles (id, email, full_name)
+  VALUES (NEW.id, NEW.email, COALESCE(NEW.raw_user_meta_data ->> 'full_name', ''));
+  RETURN NEW;
+END;
+$$;
+
+-- Trigger on auth.users table
+CREATE TRIGGER on_auth_user_created
+AFTER INSERT ON auth.users
+FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();


### PR DESCRIPTION
## Summary
- create SQL function/trigger to insert profile on user creation
- document running the new SQL scripts

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68580bb6faa88331ae59f68cc3875a03