### PR TITLE
Add avatars bucket RLS policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ psql < supabase_schema_setup.sql
 psql < supabase_add_description_column.sql
 psql < supabase_create_profile_trigger.sql
 psql < supabase_create_avatars_bucket.sql
+psql < supabase_configure_avatars_bucket_policies.sql
 
 ```
 

--- a/supabase_configure_avatars_bucket_policies.sql
+++ b/supabase_configure_avatars_bucket_policies.sql
@@ -1,0 +1,27 @@
+-- Configure RLS policies for the "avatars" storage bucket
+
+-- Enable row level security on storage.objects if not already enabled
+ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
+
+-- Allow anyone to read files from the avatars bucket
+CREATE POLICY "Public read access to avatars"
+  ON storage.objects
+  FOR SELECT
+  USING (bucket_id = 'avatars');
+
+-- Allow authenticated users to insert files into the avatars bucket
+CREATE POLICY "Authenticated insert into avatars"
+  ON storage.objects
+  FOR INSERT
+  WITH CHECK (
+    bucket_id = 'avatars' AND auth.uid() IS NOT NULL
+  );
+
+-- Allow authenticated users to update files within the avatars bucket
+CREATE POLICY "Authenticated update avatars"
+  ON storage.objects
+  FOR UPDATE
+  USING (
+    bucket_id = 'avatars' AND auth.uid() IS NOT NULL
+  )
+  WITH CHECK (bucket_id = 'avatars');


### PR DESCRIPTION
## Summary
- add SQL file to configure RLS policies for the `avatars` bucket
- update README instructions to include new policy script

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685828824d14833198dbbd4d3fb258c4