### PR TITLE
Update event status checks from active to open

### DIFF
--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -50,7 +50,7 @@ const EventRow = memo(({ event, formatDate, getStatusInfo, onDelete, deletingEve
         <Link to={`/events/${event.id}`} className="text-indigo-600 hover:text-indigo-900 mr-4">
           Voir
         </Link>
-        {event.status === 'active' && (
+        {event.status === 'open' && (
           <>
             <Link to={`/submit/${event.id}`} className="text-indigo-600 hover:text-indigo-900 mr-4">
               Soumettre une vidéo
@@ -139,7 +139,7 @@ const DashboardPage = () => {
 
   // Get event status color and label - memoized to prevent recreation on each render
   const statusMap = useMemo(() => ({
-    active: { color: 'bg-yellow-100 text-yellow-800', label: 'En cours' },
+    open: { color: 'bg-yellow-100 text-yellow-800', label: 'Ouvert' },
     ready: { color: 'bg-blue-100 text-blue-800', label: 'Prêt pour montage' },
     processing: { color: 'bg-purple-100 text-purple-800', label: 'En traitement' },
     done: { color: 'bg-green-100 text-green-800', label: 'Terminé' },

--- a/src/pages/FinalVideoPage.jsx
+++ b/src/pages/FinalVideoPage.jsx
@@ -64,9 +64,9 @@ const FinalVideoPage = () => {
     return <Loading fullPage />;
   }
 
-  const canStartProcessing = event && 
-    (event.status === 'ready' || event.status === 'active') && 
-    user && 
+  const canStartProcessing = event &&
+    (event.status === 'ready' || event.status === 'open') &&
+    user &&
     (user.id === event.user_id || user.role === 'admin');
 
   return (
@@ -85,7 +85,7 @@ const FinalVideoPage = () => {
             )}
           </div>
           <div className="mt-4 flex md:mt-0 md:ml-4 space-x-2">
-            {event && (event.status === 'active' || event.status === 'ready') && (
+            {event && (event.status === 'open' || event.status === 'ready') && (
               <Link to={`/submit/${event.id}`}>
                 <Button>
                   Soumettre une vidéo
@@ -218,16 +218,16 @@ const FinalVideoPage = () => {
                 <div className="py-4 sm:grid sm:grid-cols-3 sm:gap-4">
                   <dt className="text-sm font-medium text-gray-500">Statut</dt>
                   <dd className="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
-                    <span className={`px-2 py-1 inline-flex text-xs leading-5 font-semibold rounded-full 
-                      ${event.status === 'active' ? 'bg-yellow-100 text-yellow-800' : 
-                        event.status === 'ready' ? 'bg-blue-100 text-blue-800' : 
-                        event.status === 'processing' ? 'bg-purple-100 text-purple-800' : 
-                        event.status === 'done' ? 'bg-green-100 text-green-800' : 
+                    <span className={`px-2 py-1 inline-flex text-xs leading-5 font-semibold rounded-full
+                      ${event.status === 'open' ? 'bg-yellow-100 text-yellow-800' :
+                        event.status === 'ready' ? 'bg-blue-100 text-blue-800' :
+                        event.status === 'processing' ? 'bg-purple-100 text-purple-800' :
+                        event.status === 'done' ? 'bg-green-100 text-green-800' :
                         'bg-gray-100 text-gray-800'}`}>
-                      {event.status === 'active' ? 'En cours' : 
-                        event.status === 'ready' ? 'Prêt pour montage' : 
-                        event.status === 'processing' ? 'En traitement' : 
-                        event.status === 'done' ? 'Terminé' : 
+                      {event.status === 'open' ? 'Ouvert' :
+                        event.status === 'ready' ? 'Prêt pour montage' :
+                        event.status === 'processing' ? 'En traitement' :
+                        event.status === 'done' ? 'Terminé' :
                         event.status}
                     </span>
                   </dd>

--- a/src/pages/SubmitVideoPage.jsx
+++ b/src/pages/SubmitVideoPage.jsx
@@ -23,9 +23,9 @@ const SubmitVideoPage = () => {
         const eventData = await eventService.getEvent(eventId);
         setEvent(eventData);
         
-        // Check if event is still active
-        if (eventData.status !== 'active') {
-          setError('Cet événement n\'accepte plus de vidéos.');
+        // Check if event is still open for submissions
+        if (eventData.status !== 'open') {
+          setError("Cet événement n'accepte plus de vidéos.");
         }
         
         // Check if event deadline has passed


### PR DESCRIPTION
## Summary
- handle `open` event status for video submissions
- update event status conditions on the final video page
- update dashboard event status display

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68587b83b3288331a178ec9f7dbf4a1a