### PR TITLE
Fix invitation email HTML

### DIFF
--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -32,7 +32,12 @@ serve(async (req: Request) => {
         personalizations: [{ to: [{ email }] }],
         from: { email: FROM_EMAIL },
         subject,
-        content: [{ type: "text/plain", value: content }],
+        // Provide both text and HTML versions so the email client can render HTML
+        // while still offering a plain text fallback
+        content: [
+          { type: "text/plain", value: content },
+          { type: "text/html", value: content },
+        ],
       }),
     });
 


### PR DESCRIPTION
## Summary
- send HTML content in SendGrid emails with text fallback

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685abed389ec8331967b6b0f7f650370