### PR TITLE
Fix end_date references

### DIFF
--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -32,7 +32,7 @@ const EventRow = memo(({ event, formatDate, getStatusInfo, onDelete, deletingEve
       </td>
       <td className="px-6 py-4 whitespace-nowrap">
         <div className="text-sm text-gray-900">
-          {formatDate(event.end_date)}
+          {formatDate(event.deadline)}
         </div>
         <div className="text-sm text-gray-500">
           Date limite

--- a/src/pages/FinalVideoPage.jsx
+++ b/src/pages/FinalVideoPage.jsx
@@ -209,7 +209,7 @@ const FinalVideoPage = () => {
                 </div>
                 <div className="py-4 sm:grid sm:grid-cols-3 sm:gap-4">
                   <dt className="text-sm font-medium text-gray-500">Date limite</dt>
-                  <dd className="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">{new Date(event.end_date).toLocaleDateString('fr-FR')}</dd>
+                  <dd className="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">{new Date(event.deadline).toLocaleDateString('fr-FR')}</dd>
                 </div>
                 <div className="py-4 sm:grid sm:grid-cols-3 sm:gap-4">
                   <dt className="text-sm font-medium text-gray-500">Nombre de vidéos</dt>

--- a/src/pages/SubmitVideoPage.jsx
+++ b/src/pages/SubmitVideoPage.jsx
@@ -29,7 +29,7 @@ const SubmitVideoPage = () => {
         }
         
         // Check if event deadline has passed
-        const endDate = new Date(eventData.end_date);
+        const endDate = new Date(eventData.deadline);
         if (endDate < new Date()) {
           setError('La date limite de cet événement est dépassée.');
         }
@@ -247,7 +247,7 @@ const SubmitVideoPage = () => {
         {event && event.max_clip_duration && (
           <div className="mt-4 text-sm text-gray-500">
             <p>Durée maximale de la vidéo: {event.max_clip_duration} secondes</p>
-            <p>Date limite de soumission: {new Date(event.end_date).toLocaleDateString('fr-FR')}</p>
+            <p>Date limite de soumission: {new Date(event.deadline).toLocaleDateString('fr-FR')}</p>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- rename end_date fields to deadline on SubmitVideoPage
- update DashboardPage to show event.deadline
- update FinalVideoPage deadline display

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685adff3da608331a7a7cc1f96167963