### PR TITLE
Fix invitation link base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 VITE_SUPABASE_URL=your_supabase_url_here
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key_here
 
+# Base URL used in invitation links
+VITE_APP_BASE_URL=https://your-domain.com
+
 # Note: Never commit the actual .env file with real credentials to git
 # Replace the placeholders above with your actual Supabase credentials
 # You can find these in your Supabase project settings > API

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ cp .env.example .env
 The resulting `.env` file is listed in `.gitignore` so it will not be committed
 to the repository.
 
+Set `VITE_APP_BASE_URL` to the public URL of your deployed app so invitation
+links in emails point to the correct domain.
+
 ### Supabase setup
 
 Run the provided SQL files to initialize the database and storage. In addition

--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -188,7 +188,10 @@ const emailService = {
    * @returns {string} Full invitation URL
    */
   createInvitationLink(token) {
-    const baseUrl = window.location.origin || 'https://grega-play.com';
+    const baseUrl =
+      import.meta.env.VITE_APP_BASE_URL ||
+      (typeof window !== 'undefined' ? window.location.origin : '') ||
+      'https://grega-play.com';
     return `${baseUrl}/invitation/${token}`;
   },
 


### PR DESCRIPTION
## Summary
- make invitation link base URL configurable
- document `VITE_APP_BASE_URL` environment variable

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685ae74bb5ac8331bdb09050863ef040