### PR TITLE
Add invited events to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ uploads:
 ```sql
 \i supabase_create_videos_bucket.sql
 \i supabase_configure_videos_bucket_policies.sql
+\i supabase_get_invited_events_function.sql
 ```
 
 These scripts create a public `videos` bucket and configure row level security

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -93,11 +93,24 @@ const DashboardPage = () => {
 
   const fetchEvents = useCallback(async () => {
     if (!user) return;
-    
+
     try {
       setLoading(true);
       const userEvents = await eventService.getUserEvents(user.id);
-      setEvents(userEvents);
+      let invitedEvents = [];
+
+      if (user.email) {
+        invitedEvents = await eventService.getInvitedEvents(user.email);
+      }
+
+      const combined = [...userEvents];
+      invitedEvents.forEach(ev => {
+        if (!combined.some(e => e.id === ev.id)) {
+          combined.push(ev);
+        }
+      });
+
+      setEvents(combined);
     } catch (err) {
       console.error('Error fetching events:', err);
       setError("Impossible de charger vos événements. Veuillez réessayer.");

--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -187,6 +187,27 @@ const eventService = {
   },
 
   /**
+   * Get events a user is invited to based on their email
+   * @param {string} email - The user's email address
+   * @returns {Promise<Array>} - The invited events
+   */
+  async getInvitedEvents(email) {
+    const { data, error } = await supabase.rpc('get_invited_events', {
+      user_email: email
+    });
+
+    if (error) {
+      console.error('Error fetching invited events:', error);
+      throw new Error(error.message);
+    }
+
+    return (data || []).map(event => ({
+      ...event,
+      video_count: event.video_count || 0
+    }));
+  },
+
+  /**
    * Get an event by ID
    * @param {string} eventId - The event ID
    * @returns {Promise<Object>} - The event

--- a/supabase_get_invited_events_function.sql
+++ b/supabase_get_invited_events_function.sql
@@ -1,0 +1,39 @@
+CREATE OR REPLACE FUNCTION get_invited_events(user_email TEXT)
+RETURNS TABLE (
+    id UUID,
+    user_id UUID,
+    title TEXT,
+    description TEXT,
+    theme TEXT,
+    deadline TIMESTAMPTZ,
+    max_videos INTEGER,
+    status TEXT,
+    created_at TIMESTAMPTZ,
+    final_video_url TEXT,
+    video_count BIGINT
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    e.id,
+    e.user_id,
+    e.title,
+    e.description,
+    e.theme,
+    e.deadline,
+    e.max_videos,
+    e.status,
+    e.created_at,
+    e.final_video_url,
+    (
+      SELECT COUNT(*) FROM videos v WHERE v.event_id = e.id
+    ) AS video_count
+  FROM events e
+  JOIN invitations i ON e.id = i.event_id
+  WHERE i.email = user_email
+    AND i.status IN ('pending', 'accepted')
+  ORDER BY e.created_at DESC;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION get_invited_events(TEXT) TO authenticated;

--- a/wiki.md
+++ b/wiki.md
@@ -69,6 +69,7 @@ Grega Play is a collaborative video montage application that allows users to cre
 - **supabase_missing_tables.sql**: SQL script to create missing tables and related policies.
 - **supabase_add_description_column.sql**: SQL script to add the missing 'description' column to the 'events' table.
 - **supabase_fix_invitations_table.sql**: SQL script to fix the invitations table structure with all required columns.
+- **supabase_get_invited_events_function.sql**: Adds a helper function to retrieve events for invited users.
 - **React Template Files**: Includes all components and configurations for the React application, including services for video, invitations, and notifications.
 
 # Technology Stack


### PR DESCRIPTION
## Summary
- allow invited users to view events on their dashboard
- expose database function `get_invited_events`
- fetch invited events via `eventService`
- update docs with new SQL script

## Testing
- `pnpm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685b15b20fa48331ac4e9f1de9e0f2ed