### PR TITLE
Add get_user_events function

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ uploads:
 \i supabase_create_videos_bucket.sql
 \i supabase_configure_videos_bucket_policies.sql
 \i supabase_get_invited_events_function.sql
+\i supabase_get_user_events_function.sql
 ```
 
 These scripts create a public `videos` bucket and configure row level security

--- a/supabase_get_user_events_function.sql
+++ b/supabase_get_user_events_function.sql
@@ -1,0 +1,60 @@
+CREATE OR REPLACE FUNCTION get_user_events(p_user_id UUID, p_user_email TEXT)
+RETURNS TABLE (
+    id UUID,
+    user_id UUID,
+    title TEXT,
+    description TEXT,
+    theme TEXT,
+    deadline TIMESTAMPTZ,
+    max_videos INTEGER,
+    status TEXT,
+    created_at TIMESTAMPTZ,
+    final_video_url TEXT,
+    video_count BIGINT
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT * FROM (
+    SELECT
+      e.id,
+      e.user_id,
+      e.title,
+      e.description,
+      e.theme,
+      e.deadline,
+      e.max_videos,
+      e.status,
+      e.created_at,
+      e.final_video_url,
+      (
+        SELECT COUNT(*) FROM videos v WHERE v.event_id = e.id
+      ) AS video_count
+    FROM events e
+    WHERE e.user_id = p_user_id
+
+    UNION
+
+    SELECT
+      e.id,
+      e.user_id,
+      e.title,
+      e.description,
+      e.theme,
+      e.deadline,
+      e.max_videos,
+      e.status,
+      e.created_at,
+      e.final_video_url,
+      (
+        SELECT COUNT(*) FROM videos v WHERE v.event_id = e.id
+      ) AS video_count
+    FROM events e
+    JOIN invitations i ON e.id = i.event_id
+    WHERE i.email = p_user_email
+      AND i.status IN ('pending', 'accepted')
+  ) AS combined
+  ORDER BY created_at DESC;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION get_user_events(UUID, TEXT) TO authenticated;

--- a/wiki.md
+++ b/wiki.md
@@ -70,6 +70,7 @@ Grega Play is a collaborative video montage application that allows users to cre
 - **supabase_add_description_column.sql**: SQL script to add the missing 'description' column to the 'events' table.
 - **supabase_fix_invitations_table.sql**: SQL script to fix the invitations table structure with all required columns.
 - **supabase_get_invited_events_function.sql**: Adds a helper function to retrieve events for invited users.
+- **supabase_get_user_events_function.sql**: Returns all events a user created or is invited to.
 - **React Template Files**: Includes all components and configurations for the React application, including services for video, invitations, and notifications.
 
 # Technology Stack


### PR DESCRIPTION
## Summary
- add new SQL function `get_user_events` to fetch created and invited events for a user
- reference new script in README and wiki documentation

## Testing
- `pnpm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685bbaf60edc833189deeaa91908736f