### PR TITLE
Improve event loading with new RPC

### DIFF
--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -96,24 +96,12 @@ const DashboardPage = () => {
 
     try {
       setLoading(true);
-      const userEvents = await eventService.getUserEvents(user.id);
-      let invitedEvents = [];
-
-      if (user.email) {
-        invitedEvents = await eventService.getInvitedEvents(user.email);
-      }
-
-      const combined = [...userEvents];
-      invitedEvents.forEach(ev => {
-        if (!combined.some(e => e.id === ev.id)) {
-          combined.push(ev);
-        }
-      });
-
-      setEvents(combined);
+      const dashboardEvents = await eventService.getDashboardEvents(user.id, user.email);
+      setEvents(dashboardEvents);
+      setError(null);
     } catch (err) {
       console.error('Error fetching events:', err);
-      setError("Impossible de charger vos événements. Veuillez réessayer.");
+      setError(err?.message || "Impossible de charger vos événements. Veuillez réessayer.");
     } finally {
       setLoading(false);
     }

--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -208,6 +208,29 @@ const eventService = {
   },
 
   /**
+   * Get all dashboard events for a user (created or invited)
+   * @param {string} userId - The user's ID
+   * @param {string} email - The user's email
+   * @returns {Promise<Array>} - The dashboard events
+   */
+  async getDashboardEvents(userId, email) {
+    const { data, error } = await supabase.rpc('get_user_events', {
+      p_user_id: userId,
+      p_user_email: email
+    });
+
+    if (error) {
+      console.error('Error fetching dashboard events:', error);
+      throw new Error(error.message);
+    }
+
+    return (data || []).map(event => ({
+      ...event,
+      video_count: event.video_count || 0
+    }));
+  },
+
+  /**
    * Get an event by ID
    * @param {string} eventId - The event ID
    * @returns {Promise<Object>} - The event


### PR DESCRIPTION
## Summary
- add `getDashboardEvents` service to fetch both owned and invited events via `get_user_events` RPC
- call this new method from the dashboard

## Testing
- `pnpm install`
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685bd5f90d208331bd2fff16c70d5849