### PR TITLE
Allow invited users to read events

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ uploads:
 \i supabase_configure_videos_bucket_policies.sql
 \i supabase_get_invited_events_function.sql
 \i supabase_get_user_events_function.sql
+\i supabase_update_events_read_policy.sql
 ```
 
 These scripts create a public `videos` bucket and configure row level security

--- a/supabase_update_events_read_policy.sql
+++ b/supabase_update_events_read_policy.sql
@@ -1,0 +1,19 @@
+-- Update events read policy to allow invited users
+-- Drops the old "Users can read their own events" policy and replaces it
+-- with a policy that also grants access to users who have pending or
+-- accepted invitations.
+
+DROP POLICY IF EXISTS "Users can read their own events" ON events;
+
+CREATE POLICY "Users can read events they created or were invited to"
+  ON events
+  FOR SELECT
+  USING (
+    auth.uid() = user_id
+    OR id IN (
+      SELECT event_id
+      FROM invitations
+      WHERE email = (auth.jwt()->>'email')
+        AND status IN ('pending', 'accepted')
+    )
+  );


### PR DESCRIPTION
## Summary
- add `supabase_update_events_read_policy.sql` to extend the events RLS policy
- document running the new SQL script in the Supabase setup guide

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685c5c34fd1c83319be143e50d46b7bd