### PR TITLE
Add helper to check invited event access

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ links in emails point to the correct domain.
 
 Run the provided SQL files to initialize the database and storage. In addition
 to the existing setup scripts, execute the following to enable public video
-uploads:
+uploads and allow invited users to access events:
 
 ```sql
 \i supabase_create_videos_bucket.sql
@@ -52,10 +52,12 @@ uploads:
 \i supabase_get_invited_events_function.sql
 \i supabase_get_user_events_function.sql
 \i supabase_update_events_read_policy.sql
+\i supabase_allow_invited_event_access.sql
 ```
 
 These scripts create a public `videos` bucket and configure row level security
-policies so users can upload clips without authentication.
+policies so users can upload clips without authentication. They also set up a
+helper function for checking invitation access.
 
 ## Available Scripts
 - `pnpm install` - Install dependencies

--- a/supabase_allow_invited_event_access.sql
+++ b/supabase_allow_invited_event_access.sql
@@ -1,0 +1,14 @@
+-- Function to check if a user can access an event
+CREATE OR REPLACE FUNCTION can_access_event(p_event_id uuid, p_user_email text)
+RETURNS boolean AS $$
+BEGIN
+  RETURN EXISTS (
+    SELECT 1 FROM invitations i
+    WHERE i.event_id = p_event_id
+      AND i.email = p_user_email
+      AND i.status IN ('pending', 'accepted')
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION can_access_event(uuid, text) TO authenticated;

--- a/supabase_update_events_read_policy.sql
+++ b/supabase_update_events_read_policy.sql
@@ -10,10 +10,5 @@ CREATE POLICY "Users can read events they created or were invited to"
   FOR SELECT
   USING (
     auth.uid() = user_id
-    OR id IN (
-      SELECT event_id
-      FROM invitations
-      WHERE email = (auth.jwt()->>'email')
-        AND status IN ('pending', 'accepted')
-    )
+    OR can_access_event(id, (auth.jwt()->>'email'))
   );


### PR DESCRIPTION
## Summary
- add `can_access_event` helper
- reference helper in events read policy
- document new helper in setup instructions

## Testing
- `pnpm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c6f001c94833186f89b53f3f8976b