### PR TITLE
Fix dashboard events fetch

### DIFF
--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -96,7 +96,18 @@ const DashboardPage = () => {
 
     try {
       setLoading(true);
-
+      const dashboardEvents = await eventService.getDashboardEvents(
+        user.id,
+        user.email,
+      );
+      setEvents(dashboardEvents);
+      setError(null);
+    } catch (err) {
+      console.error('Error fetching events:', err);
+      setError(
+        err?.message ||
+          "Impossible de charger vos événements. Veuillez réessayer.",
+      );
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- use `getDashboardEvents` when loading DashboardPage

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c78b9444c83319bb773760169a5f4