### PR TITLE
Add email queue table instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,13 @@ uploads and allow invited users to access events:
 \i supabase_get_user_events_function.sql
 \i supabase_update_events_read_policy.sql
 \i supabase_allow_invited_event_access.sql
+\i supabase_create_email_queue.sql
 ```
 
 These scripts create a public `videos` bucket and configure row level security
-policies so users can upload clips without authentication. They also set up a
-helper function for checking invitation access.
+policies so users can upload clips without authentication. They also set up
+helper functions for checking invitation access and create an `email_queue`
+table used to store emails if sending fails.
 
 ## Available Scripts
 - `pnpm install` - Install dependencies

--- a/supabase_create_email_queue.sql
+++ b/supabase_create_email_queue.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS email_queue (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  to_email TEXT NOT NULL,
+  subject TEXT NOT NULL,
+  html_content TEXT NOT NULL,
+  event_id UUID REFERENCES events(id) ON DELETE CASCADE,
+  invitation_token TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+ALTER TABLE email_queue ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow inserts from authenticated" ON email_queue
+  FOR INSERT WITH CHECK (auth.role() = 'authenticated' OR auth.role() = 'service_role');
+
+CREATE POLICY "Allow service role access" ON email_queue
+  FOR SELECT USING (auth.role() = 'service_role');


### PR DESCRIPTION
## Summary
- document creation of a new `email_queue` table
- provide SQL script for email_queue

## Testing
- `pnpm install`
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685f19535b708331b599e1c09fa4bad7