### PR TITLE
Show confirmation prompt after signup

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -403,7 +403,7 @@ export const AuthProvider = ({ children }) => {
   // Update user profile
   const updateProfile = async (profileData) => {
     try {
-      if (!user) throw new Error('No user logged in');
+      if (!user) throw new Error('Merci de confirmer votre mail');
 
       const { data, error } = await supabase
         .from('profiles')


### PR DESCRIPTION
## Summary
- display a friendly message when trying to update profile without a session

## Testing
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685f2fdc76b08331b7c9fd3feca72114