### PR TITLE
Add participants management page

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,9 @@ table used to store emails if sending fails.
 - TailwindCSS
 - ESLint
 - Javascript
+
+## Inviter des participants
+
+- Depuis la page d'une vidéo finale, cliquez sur **"Inviter des participants"** pour accéder à la gestion des participants.
+- Saisissez une liste d'adresses email séparées par des virgules ou des retours à la ligne et, si besoin, un message personnel.
+- Validez le formulaire pour envoyer les invitations aux nouvelles personnes sélectionnées.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ const SubmitVideoPage = lazy(() => import('./pages/SubmitVideoPage'));
 const FinalVideoPage = lazy(() => import('./pages/FinalVideoPage'));
 const InvitationPage = lazy(() => import('./pages/InvitationPage'));
 const ProfilePage = lazy(() => import('./pages/ProfilePage'));
+const ManageParticipantsPage = lazy(() => import('./pages/ManageParticipantsPage'));
 
 // Route Guard
 const PrivateRoute = ({ children }) => {
@@ -72,6 +73,9 @@ function App() {
               } />
               <Route path="/events/:eventId" element={
                 <PrivateRoute><ErrorBoundary><FinalVideoPage /></ErrorBoundary></PrivateRoute>
+              } />
+              <Route path="/events/:eventId/participants" element={
+                <PrivateRoute><ErrorBoundary><ManageParticipantsPage /></ErrorBoundary></PrivateRoute>
               } />
 
               <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/pages/FinalVideoPage.jsx
+++ b/src/pages/FinalVideoPage.jsx
@@ -92,6 +92,13 @@ const FinalVideoPage = () => {
                 </Button>
               </Link>
             )}
+            {event && user && user.id === event.user_id && (
+              <Link to={`/events/${event.id}/participants`}>
+                <Button variant="secondary">
+                  Inviter des participants
+                </Button>
+              </Link>
+            )}
             <Link to="/dashboard">
               <Button variant="secondary">
                 Retour au tableau de bord

--- a/src/pages/ManageParticipantsPage.jsx
+++ b/src/pages/ManageParticipantsPage.jsx
@@ -1,0 +1,168 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import MainLayout from '../components/layout/MainLayout';
+import Loading from '../components/ui/Loading';
+import Button from '../components/ui/Button';
+import { useAuth } from '../context/AuthContext';
+import eventService from '../services/eventService';
+
+const ManageParticipantsPage = () => {
+  const { eventId } = useParams();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+
+  const [event, setEvent] = useState(null);
+  const [participants, setParticipants] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [sending, setSending] = useState(false);
+  const [emails, setEmails] = useState('');
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const eventData = await eventService.getEvent(eventId);
+        setEvent(eventData);
+        const partList = await eventService.getEventParticipants(eventId);
+        setParticipants(partList);
+      } catch (err) {
+        console.error('Error loading event or participants:', err);
+        setError("Erreur lors du chargement de l'événement");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [eventId]);
+
+  useEffect(() => {
+    if (!loading && event && user && user.id !== event.user_id) {
+      toast.error("Vous n'êtes pas autorisé à gérer cet événement");
+      navigate('/dashboard');
+    }
+  }, [loading, event, user, navigate]);
+
+  const handleInvite = async (e) => {
+    e.preventDefault();
+    const emailList = emails
+      .split(/[,\n]+/)
+      .map((email) => email.trim())
+      .filter(Boolean);
+
+    if (emailList.length === 0) {
+      toast.info('Veuillez entrer au moins un email');
+      return;
+    }
+
+    try {
+      setSending(true);
+      await eventService.sendInvitations(eventId, emailList, event, message);
+      const updated = await eventService.getEventParticipants(eventId);
+      setParticipants(updated);
+      setEmails('');
+      setMessage('');
+    } catch (err) {
+      console.error('Error sending invitations:', err);
+      toast.error(err.message || "Erreur lors de l'envoi des invitations");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <MainLayout>
+        <div className="py-8 flex justify-center">
+          <Loading />
+        </div>
+      </MainLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <MainLayout>
+        <div className="py-8 text-center text-red-500">{error}</div>
+      </MainLayout>
+    );
+  }
+
+  return (
+    <MainLayout>
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-gray-900">{event.title}</h1>
+          <p className="text-sm text-gray-500">Gestion des participants</p>
+        </div>
+
+        <div className="bg-white shadow sm:rounded-lg mb-6">
+          <div className="px-4 py-5 sm:p-6">
+            <h2 className="text-lg font-medium text-gray-900 mb-4">Participants actuels</h2>
+            {participants.length === 0 ? (
+              <p className="text-sm text-gray-500">Aucun participant</p>
+            ) : (
+              <ul className="divide-y divide-gray-200">
+                {participants.map((p) => (
+                  <li key={p.email} className="py-2 flex justify-between">
+                    <span>{p.email}</span>
+                    <span className="text-sm text-gray-500">
+                      {p.status}
+                      {p.has_submitted ? ' (vidéo soumise)' : ''}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+
+        <div className="bg-white shadow sm:rounded-lg mb-6">
+          <form onSubmit={handleInvite}>
+            <div className="px-4 py-5 sm:p-6">
+              <h2 className="text-lg font-medium text-gray-900 mb-4">Inviter de nouveaux participants</h2>
+              <div className="mb-4">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Emails (séparés par des virgules ou des retours à la ligne)
+                </label>
+                <textarea
+                  value={emails}
+                  onChange={(e) => setEmails(e.target.value)}
+                  rows={3}
+                  className="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md"
+                ></textarea>
+              </div>
+              <div className="mb-4">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Message personnel (optionnel)
+                </label>
+                <textarea
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                  rows={2}
+                  className="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md"
+                ></textarea>
+              </div>
+              <div className="flex justify-end">
+                <Button type="submit" loading={sending} disabled={sending}>
+                  Envoyer les invitations
+                </Button>
+              </div>
+            </div>
+          </form>
+        </div>
+
+        <div className="flex justify-end">
+          <Link to={`/events/${eventId}`} className="mr-3">
+            <Button variant="secondary">Retour à l'événement</Button>
+          </Link>
+        </div>
+      </div>
+    </MainLayout>
+  );
+};
+
+export default ManageParticipantsPage;


### PR DESCRIPTION
## Summary
- create `ManageParticipantsPage` to list and invite participants
- add route `/events/:eventId/participants`
- link invitation management from final video page
- document how to invite participants

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685f392f68c0833197b1f2c373009889