### PR TITLE
Update videos insert policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,15 @@ uploads and allow invited users to access events:
 \i supabase_update_events_read_policy.sql
 \i supabase_allow_invited_event_access.sql
 \i supabase_create_email_queue.sql
+\i supabase_update_videos_insert_policy.sql
 ```
 
 These scripts create a public `videos` bucket and configure row level security
 policies so users can upload clips without authentication. They also set up
 helper functions for checking invitation access and create an `email_queue`
-table used to store emails if sending fails.
+table used to store emails if sending fails. The final command updates the
+`videos` table policy so only authenticated users invited to an event can add
+clips.
 
 ## Available Scripts
 - `pnpm install` - Install dependencies

--- a/supabase_update_videos_insert_policy.sql
+++ b/supabase_update_videos_insert_policy.sql
@@ -1,0 +1,9 @@
+-- Restrict video insertion to authenticated users invited to the event
+DROP POLICY IF EXISTS "Anyone can insert videos" ON videos;
+CREATE POLICY "Invited users can insert videos"
+  ON videos
+  FOR INSERT
+  WITH CHECK (
+    auth.uid() IS NOT NULL
+    AND can_access_event(event_id, auth.jwt()->>'email')
+  );


### PR DESCRIPTION
## Summary
- enforce invited-only video insertion with a new SQL script
- document running this script in the setup instructions

## Testing
- `pnpm install`
- `pnpm run lint`
- `psql -h db.ppikuvruvlzuwcpgpsyp.supabase.co -U postgres -d postgres -p 5432 -f supabase_update_videos_insert_policy.sql` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68602c3d7bd88331aaf2afcbfade4e99