### PR TITLE
Update video insertion policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ These scripts create a public `videos` bucket and configure row level security
 policies so users can upload clips without authentication. They also set up
 helper functions for checking invitation access and create an `email_queue`
 table used to store emails if sending fails. The final command updates the
-`videos` table policy so only authenticated users invited to an event can add
+`videos` table policy so event creators and invited users can add
 clips.
 
 ## Available Scripts

--- a/supabase_update_videos_insert_policy.sql
+++ b/supabase_update_videos_insert_policy.sql
@@ -1,9 +1,12 @@
--- Restrict video insertion to authenticated users invited to the event
-DROP POLICY IF EXISTS "Anyone can insert videos" ON videos;
-CREATE POLICY "Invited users can insert videos"
+-- Drop old policy and allow creators or invited users to add videos
+DROP POLICY IF EXISTS "Invited users can insert videos" ON videos;
+CREATE POLICY "Creators and invited users can insert videos"
   ON videos
   FOR INSERT
   WITH CHECK (
     auth.uid() IS NOT NULL
-    AND can_access_event(event_id, auth.jwt()->>'email')
+    AND (
+      auth.uid() = (SELECT user_id FROM events WHERE id = event_id)
+      OR can_access_event(event_id, auth.jwt()->>'email')
+    )
   );


### PR DESCRIPTION
## Summary
- adjust Supabase videos INSERT policy to allow creators as well as invited users
- clarify README on who can upload clips

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68606b0414888331a188c6d3c3adcd36