### PR TITLE
Fix duplicate videos insert policies

### DIFF
--- a/supabase_update_videos_insert_policy.sql
+++ b/supabase_update_videos_insert_policy.sql
@@ -1,4 +1,7 @@
 -- Drop old policy and allow creators or invited users to add videos
+DROP POLICY IF EXISTS "All connected users can insert videos" ON videos;
+DROP POLICY IF EXISTS "Allow creators and invited participants to insert" ON videos;
+DROP POLICY IF EXISTS "Anyone can insert videos" ON videos;
 DROP POLICY IF EXISTS "Invited users can insert videos" ON videos;
 CREATE POLICY "Creators and invited users can insert videos"
   ON videos


### PR DESCRIPTION
## Summary
- update the base schema to create only one `INSERT` policy for `videos`
- update migration to drop obsolete insert policies before creating the final one

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686274769b448331b573b4d47eeff870