### PR TITLE
Fix terms & privacy links

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,8 @@ const FinalVideoPage = lazy(() => import('./pages/FinalVideoPage'));
 const InvitationPage = lazy(() => import('./pages/InvitationPage'));
 const ProfilePage = lazy(() => import('./pages/ProfilePage'));
 const ManageParticipantsPage = lazy(() => import('./pages/ManageParticipantsPage'));
+const TermsPage = lazy(() => import('./pages/TermsPage'));
+const PrivacyPolicyPage = lazy(() => import('./pages/PrivacyPolicyPage'));
 
 // Route Guard
 const PrivateRoute = ({ children }) => {
@@ -60,6 +62,8 @@ function App() {
               <Route path="/invitation/:token" element={<ErrorBoundary><InvitationPage /></ErrorBoundary>} />
               <Route path="/submit/:eventId" element={<ErrorBoundary><SubmitVideoPage /></ErrorBoundary>} />
               <Route path="/final/:eventId" element={<ErrorBoundary><FinalVideoPage /></ErrorBoundary>} />
+              <Route path="/terms" element={<ErrorBoundary><TermsPage /></ErrorBoundary>} />
+              <Route path="/privacy" element={<ErrorBoundary><PrivacyPolicyPage /></ErrorBoundary>} />
 
               {/* Protected routes */}
               <Route path="/dashboard" element={

--- a/src/components/auth/RegisterForm.jsx
+++ b/src/components/auth/RegisterForm.jsx
@@ -222,13 +222,13 @@ const RegisterForm = () => {
             />
             <label htmlFor="terms" className="ml-2 block text-sm text-gray-900">
               J'accepte les{' '}
-              <a href="#" className="font-medium text-indigo-600 hover:text-indigo-500">
+              <Link to="/terms" className="font-medium text-indigo-600 hover:text-indigo-500">
                 conditions d'utilisation
-              </a>{' '}
+              </Link>{' '}
               et la{' '}
-              <a href="#" className="font-medium text-indigo-600 hover:text-indigo-500">
+              <Link to="/privacy" className="font-medium text-indigo-600 hover:text-indigo-500">
                 politique de confidentialité
-              </a>
+              </Link>
             </label>
           </div>
 

--- a/src/pages/PrivacyPolicyPage.jsx
+++ b/src/pages/PrivacyPolicyPage.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import MainLayout from '../components/layout/MainLayout';
+
+const PrivacyPolicyPage = () => (
+  <MainLayout>
+    <div className="max-w-3xl mx-auto bg-white p-6 rounded shadow">
+      <h1 className="text-2xl font-bold mb-4">Politique de confidentialité</h1>
+      <p className="text-gray-700">
+        Ceci est un exemple de texte pour la politique de confidentialité.
+        Remplacez-le par vos propres informations sur la collecte et
+        l'utilisation des données.
+      </p>
+    </div>
+  </MainLayout>
+);
+
+export default PrivacyPolicyPage;

--- a/src/pages/TermsPage.jsx
+++ b/src/pages/TermsPage.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import MainLayout from '../components/layout/MainLayout';
+
+const TermsPage = () => (
+  <MainLayout>
+    <div className="max-w-3xl mx-auto bg-white p-6 rounded shadow">
+      <h1 className="text-2xl font-bold mb-4">Conditions d'utilisation</h1>
+      <p className="text-gray-700">
+        Ceci est un exemple de texte pour les conditions d'utilisation. Vous
+        pouvez remplacer ce contenu par vos propres termes légaux.
+      </p>
+    </div>
+  </MainLayout>
+);
+
+export default TermsPage;


### PR DESCRIPTION
## Summary
- add TermsPage and PrivacyPolicyPage
- link to them in the register form
- update the router to include new pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6865705ee20483319e4702e83465d50b